### PR TITLE
Potential fix for code scanning alert no. 118: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,4 +1,6 @@
 name: Renovate
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/cthtrifork/homeserver-centos-bootc/security/code-scanning/118](https://github.com/cthtrifork/homeserver-centos-bootc/security/code-scanning/118)

To fix the issue, explicitly set the `permissions` key at the top level of the workflow file, just below the `name` (and above or below the `on:` block), or at the job level if only specific jobs need it. Since Renovate only needs to read repository contents for most operations, the minimal required permissions can be safely set to `contents: read`. If Renovate requires more permissions (e.g., writing to pull requests), more granular scopes could be added as needed. For now, apply the recommended least required permission.

The required edit is to insert the following YAML:

```yaml
permissions:
  contents: read
```

This should be placed after the `name:` line and before `on:` or immediately following `on:`, per YAML best practice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
