### PR TITLE
Add systemd service configuration for GitHub Actions Runner

### DIFF
--- a/github-runner.containerfile
+++ b/github-runner.containerfile
@@ -64,7 +64,7 @@ RUN --mount=type=bind,from=ctx,src=/,dst=/ctx \
 RUN --mount=type=bind,from=ctx,src=/,dst=/ctx \
     --mount=type=tmpfs,dst=/tmp \
      mkdir -p /etc/containers/systemd && \
-     cp -r /ctx/system_files/githubrunner/containers/* /etc/containers/systemd/
+     ln -sr /usr/share/containers/systemd/github-runner.container /etc/containers/systemd/github-runner.container
 
 # Activate services
 RUN systemctl enable docker.socket && \

--- a/system_files/githubrunner/usr/share/containers/systemd/github-runner.container
+++ b/system_files/githubrunner/usr/share/containers/systemd/github-runner.container
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/homeserver/metadata/github-runner
 Environment=RUNNER_LABELS=self-hosted,Linux,X64,Ubuntu
 
 Volume=/usr/libexec/entrypoint.sh:/entrypoint.sh
-Volume=/var/lib/actions-runner/_work:/_work
+Volume=/var/lib/github-runner/_work:/_work
 
 # If you want docker-compatible socket for docker-based actions:
 Volume=/run/podman/podman.sock:/var/run/docker.sock
@@ -25,10 +25,10 @@ Exec=/bin/bash -lc "/entrypoint.sh"
 # Network=host
 
 [Service]
-User=runner
-Group=runner
+#User=runner
+#Group=runner
 
-WorkingDirectory=/var/lib/actions-runner
+#WorkingDirectory=/var/lib/actions-runner
 
 Restart=always
 RestartSec=5s

--- a/system_files/githubrunner/usr/share/containers/systemd/github-runner.container
+++ b/system_files/githubrunner/usr/share/containers/systemd/github-runner.container
@@ -16,7 +16,7 @@ Volume=/usr/libexec/entrypoint.sh:/entrypoint.sh
 Volume=/var/lib/github-runner/_work:/_work
 
 # If you want docker-compatible socket for docker-based actions:
-Volume=/run/podman/podman.sock:/var/run/docker.sock
+Volume=/var/run/docker.sock:/var/run/docker.sock
 
 # Run our entrypoint inside the container
 Exec=/bin/bash -lc "/entrypoint.sh"


### PR DESCRIPTION
Introduce a systemd service configuration to manage the GitHub Actions Runner, enabling it to run as a container with specified environment settings and restart policies.