### PR TITLE
Update test job to run for non-draft PRs with 'e2e' label

### DIFF
--- a/.github/workflows/build-bootc-images.yaml
+++ b/.github/workflows/build-bootc-images.yaml
@@ -446,7 +446,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: build-bootc-image
-    if: ${{ github.event_name == 'pull_request' }}
+    # only run if tagged for testing
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'e2e') }}
     continue-on-error: false
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Modify the test job to execute only for non-draft pull requests that are labeled with 'e2e', optimizing the workflow for relevant tests.